### PR TITLE
Integrate anythingllm into main

### DIFF
--- a/app/llm_integration.py
+++ b/app/llm_integration.py
@@ -1,0 +1,18 @@
+# app/llm_integration.py
+import torch
+from transformers import pipeline
+
+# Check if GPU is available and print the status
+cuda_available = torch.cuda.is_available()
+print(f"CUDA is available: {cuda_available}")
+
+# Set the device based on CUDA availability
+device = 0 if cuda_available else -1  # Use GPU if available, otherwise CPU
+
+# Specify the model you want to use
+model_name = "sshleifer/distilbart-cnn-12-6"
+summarizer = pipeline("summarization", model=model_name)
+
+def generate_summary(text):
+    summary = summarizer(text, max_length=150, min_length=40, do_sample=False)
+    return summary[0]['summary_text']

--- a/app/main.py
+++ b/app/main.py
@@ -1,14 +1,24 @@
 # app/main.py
 from fastapi import FastAPI, UploadFile, File
-from app.data_processing.py import load_data, get_summary_statistics
+from app.data_processing import load_data, get_summary_statistics
+from app.llm_integration import generate_summary
+import asyncio
 
 app = FastAPI()
+
+# Define a semaphore with a limit of 2 concurrent accesses
+semaphore = asyncio.Semaphore(2)
 
 @app.post("/uploadfile/")
 async def create_upload_file(file: UploadFile = File(...)):
     data = load_data(file.file)
     summary = get_summary_statistics(data)
     return summary.to_dict()
+
+@app.post("/summarize/")
+async def summarize_text(text: str):
+    summary = generate_summary(text)
+    return {"summary": summary}
 
 @app.get("/")
 def read_root():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 fastapi
 uvicorn
 pandas
+transformers
+torch


### PR DESCRIPTION
Following what I saw online and via ChatGPT as a secondary source:
- Importing transformers and torch for requirements.txt
- Integrating summarize and appllm into main.py (to work with FastAPI)
- Create LLM_integration.py, check if GPU available (use CPU otherwise), specify sample model to use for now